### PR TITLE
fix: ignore shared workflows pinning by filename

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -105,7 +105,8 @@
       ]
     },
     {
-      "matchPackageNames": ["/^immich-app\\/devtools\\/.github\\/workflows\\/shared-/"],
+      "matchPackageNames": ["immich-app/devtools"],
+      "matchFileNames": [".github/workflows/org-**"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Turns out the package name doesn't actually include the action path like I thought.