### PR TITLE
fix: exclude org workflows from renovate everywhere

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -106,7 +106,7 @@
     },
     {
       "matchPackageNames": ["immich-app/devtools"],
-      "matchFileNames": [".github/workflows/org-**"],
+      "matchFileNames": ["**/.github/workflows/org-**"],
       "enabled": false
     },
     {
@@ -115,8 +115,8 @@
       "groupName": "github-actions",
       "ignoreUnstable": false,
       "versionCompatibility": "^(?<compatibility>.*)-(?<version>.*)$",
-      "minimumReleaseAge": "0",                                                                                                                      
-      "extractVersion": "^(?<version>.+)$" 
+      "minimumReleaseAge": "0",
+      "extractVersion": "^(?<version>.+)$"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
In devtools#1465, it's trying to pin the source files in the tf/ dir too.