### PR TITLE
fix: set minimumReleaseAge behaviour to optional

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -9,6 +9,7 @@
   ],
   "recreateWhen": "never",
   "minimumReleaseAge": "5 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "schedule": "before 9am on tuesday",
   "prConcurrentLimit": 0,
   "labels": ["dependencies", "renovate", "changelog:skip"],


### PR DESCRIPTION
Without, on sources that don't provide the age, it never opens a PR at all