### PR TITLE
fix: match YAML list items in renovate regex manager

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -136,7 +136,7 @@
       "description": "Process custom dependencies",
       "managerFilePatterns": ["/.*/"],
       "matchStrings": [
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n.*?[:=]\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n(?:.*?[:=]|\\s*-)\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"


### PR DESCRIPTION
The regex manager's `[:=]` requirement (introduced in #32) means annotated YAML list items are not matched:

```yaml
vectorchord:
  # renovate: datasource=github-releases depName=tensorchord/VectorChord
  - "0.5.3"
```

This adds an alternation branch for list items: `(?:.*?[:=]|\s*-)`. The `[:=]` branch is tried first, so every line the current regex matches extracts exactly the same value as before; only lines with no `:`/`=` at all fall through to the list-item branch.

Verified against the annotation formats currently in use across the org (`ARG FOO=x`, `KEY="x"`, yaml `version: x`, sqlite-libs' commit pins) plus the new list format — needed for the base-images postgres build matrix in `postgres/versions.yaml`.