### PR TITLE
feat: add org zizmor config

### DIFF
--- a/zizmor-config.yml
+++ b/zizmor-config.yml
@@ -1,0 +1,10 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "immich-app/devtools/.github/workflows/shared-zizmor.yml": ref-pin
+        "immich-app/devtools/.github/workflows/shared-pr-require-conventional-commit.yml": ref-pin
+        "*": hash-pin
+  secrets-inherit:
+    ignore:
+      - org-zizmor.yml


### PR DESCRIPTION
Shared zizmor policy for all repos, fetched by the shared-zizmor workflow. Mirrors how renovate-config.json is consumed as a preset.

Exempts the org-managed workflow refs that intentionally track @main and the secrets: inherit in org-zizmor.yml. Everything else stays hash-pinned.