### PR TITLE
feat: route 0.x minor updates onto the major branches

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -125,6 +125,12 @@
       "versionCompatibility": "^(?<compatibility>.*)-(?<version>.*)$",
       "minimumReleaseAge": "0",
       "extractVersion": "^(?<version>.+)$"
+    },
+    {
+      "description": "zer0ver: 0.x minors can break at any time, route them onto the major branches",
+      "matchUpdateTypes": ["minor"],
+      "matchCurrentVersion": "/^v?0\\./",
+      "additionalBranchPrefix": "major-"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Renovate classifies `0.x → 0.y` as a minor update even though SemVer gives 0.x releases no stability guarantee, so today a breaking zero-ver bump rides the same weekly grouped PR as genuinely safe minors and patches (`typescript-projects`, `github-actions`, ...). This adds one rule that sets `additionalBranchPrefix: "major-"` for minors whose current version is 0.x, which lands them on the same `major-<groupSlug>` branch Renovate already uses to split grouped majors - so risky bumps get their own PR and the regular group PRs stay skimmable. Ungrouped 0.x minors just get a `major-` branch rename.

The devtools per-component tags are handled correctly: `versionCompatibility` strips the `<component>-` prefix before version matching, so `image-build-action-v0.1.9` is seen as `v0.1.9` and routed, while `use-mise-action-v3.2.1` is untouched. The only transition cost is a one-time regroup of open PRs that contain 0.x minors.