### PR TITLE
fix: disbale lockfile maintenance

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -14,12 +14,6 @@
   "prConcurrentLimit": 0,
   "labels": ["dependencies", "renovate", "changelog:skip"],
   "postUpdateOptions": ["pnpmDedupe"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 9am on the 1st day of the month"],
-    "commitMessageExtra": "({{manager}})",
-    "additionalBranchPrefix": "{{manager}}-"
-  },
   "packageRules": [
     {
       "groupName": "@immich/ui",


### PR DESCRIPTION
These PRs always seem to have problems, sit around a long time, and never get merged in, so disabling.